### PR TITLE
Fix a bug about a defunct state kill process

### DIFF
--- a/src/widgets/proc.go
+++ b/src/widgets/proc.go
@@ -249,6 +249,7 @@ func (self *Proc) Kill() {
 	}
 	cmd := exec.Command(command, self.Rows[self.SelectedRow][self.UniqueCol])
 	cmd.Start()
+	cmd.Wait()
 }
 
 /////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
When using dd shortcut to kill a process, a kill process with a defunct state is left.